### PR TITLE
Allow limiting counts

### DIFF
--- a/light_sensor.py
+++ b/light_sensor.py
@@ -11,6 +11,7 @@ GPIO.setmode(GPIO.BOARD)
 
 #define the pin that goes to the circuit
 pin_to_circuit = 7
+max_count = 100000
 
 def rc_time (pin_to_circuit):
     count = 0
@@ -26,6 +27,8 @@ def rc_time (pin_to_circuit):
     #Count until the pin goes high
     while (GPIO.input(pin_to_circuit) == GPIO.LOW):
         count += 1
+        if count == max_count:
+            break
 
     return count
 


### PR DESCRIPTION
When it is dark, it may take some time before the script returns a value. When action depends on a sequence of readings from the sensor, this may cause the sensor to appear a bit unresponsive. In addition to this, limiting counts is beneficial in normal light conditions when small-capacity capacitor is not available, and a somehow larger capacitor is used (I have tested it with up to 470uF).